### PR TITLE
Add instructions on how to use addons:attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,38 @@ heroku ps:scale worker=1
 ```
 
 Done! You should start to see data coming into your NewRelic dashboard as soon as the deploy is finished.
+
+Bonus
+------------------------
+
+#### Keeping your DATABASE_URL up-to-date with Heroku attach
+Heroku automatically manages your DATABASE_URL in your main application for you. If your database server fails or for some reason Heroku moves your database to a new host, they will update your DATABASE_URL in your main application.
+We can have Heroku update our DATABASE_URL in our Heroku Postgres Monitor app as well by using `addons:attach`.
+
+First, install the addon-attachments plugin. This allows you to attach a single Heroku addon to multiple applications.
+```
+heroku plugins:install https://github.com/heroku/heroku-addon-attachments.git
+```
+
+Next, list your existing attachments for the primary application you are monitoring.
+```
+heroku addons --app your_main_application_name
+=== Resources for your_main_application_name
+Plan                         Name                      Price
+---------------------------  ------------------------  --------------
+heroku-postgresql:premium-4  funny-name-1234       $xx.xx/month
+
+
+=== Attachments for your_main_application_name
+Name                        Add-on                    Billing App
+--------------------------  ------------------------  -----------
+DATABASE                    funny-name-1234            your_main_application_name
+```
+
+Now, you'll use your add-on name from the previous command to attach it to your Heroku Postgres Monitor app.
+
+```
+heroku addons:attach funny-name-1234 --as DATABASE
+```
+
+That's it, now if for some reason your DATABASE_URL has to change in your main application. Your monitoring will be updated as well.


### PR DESCRIPTION
Hey, this project is awesome. Super easy to get up and running. :star2: :star: 

One thing that I think should be added to the documentation, is instructions for Heroku's new `addon:attach`.

When a Heroku Postgres database has a server issue. Heroku will automatically move the database to another server. When they do this they will update the `DATABASE_URL` in your main application as well.

This adds instructions on how to use `addons:attach` with Heroku Postgres Monitor to have Heroku automatically update the database_url there as well.
